### PR TITLE
Remove limitation of x86_64

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,4 +2,3 @@
 # tasks file for ossec-role
 
 - include: ossec.yml
-  when: ansible_architecture == 'x86_64'


### PR DESCRIPTION
Since ossec can be compiled on a wide variety of architectures, it is reasonable to remove the limitation on x86_64 architectures
